### PR TITLE
GitHub Issue 05 Properly include sematic ui css

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />
     <title>React App</title>
   </head>
   <body>

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -5,11 +5,6 @@ export function Filter({ styling, filterColumns, onChange, dataSet }) {
   // Defines a filter which allows users to filter data displayed on graph
   // by selecting certain datasources and/or campaigns.
   const columns = [];
-  const styleLink = document.createElement("link");
-  styleLink.rel = "stylesheet";
-  styleLink.href =
-    "https://cdn.jsdelivr.net/npm/semantic-ui/dist/semantic.min.css";
-  document.head.appendChild(styleLink);
 
   for (let item = 0; item < filterColumns.length; item++) {
     const genOptions = generateOptions(filterColumns[item], dataSet);
@@ -20,7 +15,6 @@ export function Filter({ styling, filterColumns, onChange, dataSet }) {
         </p>
         <Dropdown
           key={item}
-          style={styleLink}
           placeholder={filterColumns[item]}
           fluid
           multiple


### PR DESCRIPTION
Closes #5 

Integrated with the following code in index.html:
```
<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />
```